### PR TITLE
Correct the JS script order

### DIFF
--- a/examples/multiple.blade.php
+++ b/examples/multiple.blade.php
@@ -17,9 +17,9 @@
     {!! app('captcha')->display() !!}
     {{--    {!! app('captcha')->display([], ['multiple' => true]) !!}--}}
 </form>
-{!! app('captcha')->displayJs() !!}
 {!! app('captcha')->displayMultiple() !!}
 {{--{!! app('captcha')->displayMultiple(['multiple' => true]) !!}--}}
+{!! app('captcha')->displayJs() !!}
 <button id="reset_1">Reset 1</button>
 <button id="reset_all">Reset all</button>
 <script>


### PR DESCRIPTION
According to https://developers.google.com/recaptcha/docs/display#explicit_render :

> Note: your onload callback function must be defined before the reCAPTCHA API loads. To ensure there are no race conditions:
    order your scripts with the callback first, and then reCAPTCHA
    use the async and defer parameters in the script tags

