### PR TITLE
Reserved characters in HTML must be replaced with character entities.

### DIFF
--- a/src/Captcha.php
+++ b/src/Captcha.php
@@ -118,7 +118,7 @@ class Captcha
             $query['hl'] = $lang;
         }
 
-        return static::CAPTCHA_CLIENT_API . '?' . http_build_query($query);
+        return static::CAPTCHA_CLIENT_API . '?' . http_build_query($query, null, '&amp;');
     }
 
     /**


### PR DESCRIPTION
from w3schools.com